### PR TITLE
Add debug logging for library loading failures

### DIFF
--- a/lib/jcs_bindings.ml
+++ b/lib/jcs_bindings.ml
@@ -1,6 +1,11 @@
 open Ctypes
 open Foreign
 
+let debug_enabled =
+  match Sys.getenv_opt "DEBUG" with
+  | Some "1" | Some "true" | Some "yes" -> true
+  | _ -> false
+
 let try_paths = [
   Sys.getenv_opt "REZNJCS_LIB_PATH";
   Some "/usr/lib/rezndsl/libreznjcs.so";
@@ -14,7 +19,8 @@ let lib =
     | path :: rest ->
         try Dl.dlopen ~filename:path ~flags:[Dl.RTLD_NOW]
         with Dl.DL_error err ->
-          prerr_endline ("[WARN] Failed to load: " ^ path ^ " - " ^ err);
+          if debug_enabled then
+            prerr_endline ("[WARN] Failed to load: " ^ path ^ " - " ^ err);
           try_load rest
   in
   try_load try_paths


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to enable debug warnings by setting the `DEBUG` environment variable.
- **Refactor**
  - Warning messages for failed library loading are now shown only when debugging is enabled, reducing unnecessary output for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->